### PR TITLE
support building against a qt without a11y enabled

### DIFF
--- a/src/kcollapsiblegroupbox.cpp
+++ b/src/kcollapsiblegroupbox.cpp
@@ -97,7 +97,9 @@ void KCollapsibleGroupBox::setTitle(const QString& title)
 
     d->shortcutId = grabShortcut(QKeySequence::mnemonic(title));
 
+#ifndef QT_NO_ACCESSIBILITY
     setAccessibleName(title);
+#endif
 
     emit titleChanged();
 }


### PR DESCRIPTION
Reviewers: cfeck

Reviewed By: cfeck

Subscribers: #frameworks

Tags: #frameworks

Differential Revision: https://phabricator.kde.org/D5212